### PR TITLE
NRE fixed I hope

### DIFF
--- a/src/Lykke.Service.EthereumClassicApi.Blockchain/Parity.cs
+++ b/src/Lykke.Service.EthereumClassicApi.Blockchain/Parity.cs
@@ -33,7 +33,7 @@ namespace Lykke.Service.EthereumClassicApi.Blockchain
             var request = new RpcRequest($"{NewGuid.Get()}", "trace_transaction", txHash);
             var response = await _web3Parity.Client.SendRequestAsync<JArray>(request);
 
-            return response.Select(x => x["error"]?.ToString()).FirstOrDefault();
+            return response?.Select(x => x?["error"]?.ToString()).FirstOrDefault();
         }
     }
 }


### PR DESCRIPTION
Exception example:

```
Time: 10/04/2019 15:50:11

Sender: [2019-10-04 15:50:09] Lykke.Service.EthereumClassicApi 1.0.5.0 : etc-api-6d9f666bcc-tljzn : [akka://ethereum-classic/user/transaction-monitors-dispatcher/transation-monitors/$b#1277760298]
Message: Value cannot be null.
Parameter name: source
 : System.ArgumentNullException: Value cannot be null.
Parameter name: source
   at System.Linq.Enumerable.Select[TSource,TResult](IEnumerable`1 source, Func`2 selector)
   at async Lykke.Service.EthereumClassicApi.Blockchain.Parity.GetTransactionErrorAsync(?) in /home/lykkex/buildAgent/work/4ba340b8f9bce826/src/Lykke.Service.EthereumClassicApi.Blockchain/Parity.cs:line 36
   at async Lykke.Service.EthereumClassicApi.Services.TransactionStateService.GetTransactionStateAsync(?) in /home/lykkex/buildAgent/work/4ba340b8f9bce826/src/Lykke.Service.EthereumClassicApi.Services/TransactionStateService.cs:line 34
   at async Lykke.Service.EthereumClassicApi.Actors.Roles.TransactionMonitorRole.CheckTransactionStatesAsync(?) in /home/lykkex/buildAgent/work/4ba340b8f9bce826/src/Lykke.Service.EthereumClassicApi.Actors/Roles/TransactionMonitorRole.cs:line 35
   at async Lykke.Service.EthereumClassicApi.Actors.TransactionMonitorActor.ProcessMessageAsync(?) in /home/lykkex/buildAgent/work/4ba340b8f9bce826/src/Lykke.Service.EthereumClassicApi.Actors/TransactionMonitorActor.cs:line 34 : Operation failed:{"Duration":5809,"Thread":"0011","Trigger":{"OperationId":"56a86268-bc59-4040-9af8-4a39b0d4d27a"}}
```